### PR TITLE
fix: support elementary OS installer detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,16 +15,31 @@ fi
 
 # 2. Check OS distribution and set package manager
 OS_TYPE=""
+OS_LIKE=""
 PKG_MGR=""
 if [ -f /etc/os-release ]; then
     . /etc/os-release
-    OS_TYPE=$ID
+    OS_TYPE=${ID:-}
+    OS_LIKE=${ID_LIKE:-}
 fi
 
 case "$OS_TYPE" in
-    ubuntu|debian)
+    ubuntu|debian|elementary)
         PKG_MGR="apt-get"
         export DEBIAN_FRONTEND=noninteractive
+        ;;
+    *)
+        case " $OS_LIKE " in
+            *" ubuntu "*|*" debian "*)
+                PKG_MGR="apt-get"
+                export DEBIAN_FRONTEND=noninteractive
+                ;;
+        esac
+        ;;
+esac
+
+case "$OS_TYPE" in
+    ubuntu|debian|elementary)
         ;;
     alpine)
         PKG_MGR="apk"
@@ -37,8 +52,10 @@ case "$OS_TYPE" in
         fi
         ;;
     *)
-        echo -e "${RED}错误: 不支持的操作系统 ($OS_TYPE)！目前仅支持 Ubuntu/Debian/Alpine/CentOS/RHEL/Rocky/AlmaLinux/Fedora/OracleLinux/AmazonLinux。${PLAIN}"
-        exit 1
+        if [ -z "$PKG_MGR" ]; then
+            echo -e "${RED}错误: 不支持的操作系统 ($OS_TYPE)！目前仅支持 Ubuntu/Debian/Alpine/CentOS/RHEL/Rocky/AlmaLinux/Fedora/OracleLinux/AmazonLinux 及其兼容发行版。${PLAIN}"
+            exit 1
+        fi
         ;;
 esac
 

--- a/tests/test_manager_logic.py
+++ b/tests/test_manager_logic.py
@@ -857,6 +857,13 @@ class ManagerLogicTests(unittest.TestCase):
         self.assertNotIn("origin/master", install_text)
         self.assertNotIn("bate", install_text.lower())
 
+    def test_installer_accepts_elementary_and_debian_derivatives(self) -> None:
+        install_text = (manager.ROOT_DIR / "install.sh").read_text(encoding="utf-8")
+
+        self.assertIn("OS_LIKE=${ID_LIKE:-}", install_text)
+        self.assertIn("ubuntu|debian|elementary)", install_text)
+        self.assertIn('*" ubuntu "*|*" debian "*)', install_text)
+
     def test_installer_uses_secure_credentials_and_current_version(self) -> None:
         install_text = (manager.ROOT_DIR / "install.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
### Problem
The installer rejects elementary OS because it checks only `ID=elementary` and does not use the Debian/Ubuntu compatibility metadata.

### Changes
- Recognize elementary OS as an apt-based distribution.
- Detect Ubuntu/Debian derivatives through `ID_LIKE`.
- Add regression coverage for the installer detection contract.

### Verification
- `bash -n install.sh`
- `python3 -m unittest discover -s tests -v` (54 tests passed)

Docker Compose validation was unavailable locally because Docker is not installed.